### PR TITLE
Decode Cooler Master MasterKeys Pro firmware updaters

### DIFF
--- a/updatepackage.cpp
+++ b/updatepackage.cpp
@@ -85,6 +85,16 @@ const ZMap<zu64, PackType> packages = {
     // Mistel Freeboard MD200 (200)
     // Vortex Tester (200)
     { 0x58B42FF4B1C57C09,   MAAV102 },  // V1.01.02     md200/v112
+
+    // Cooler Master Masterkeys Pro L White
+    { 0x38cc849b2e54b6df,   MAAV102 },  // V1.08.00     cmprolwhite/v180
+
+    // Cooler Master Masterkeys Pro M White
+    { 0x12fbf4668bdfe188,   MAAV102 },  // V1.06.00
+
+    // Cooler Master Masterkeys Pro M RGB
+    { 0xfdf7ac5b93d67ead,   MAAV102 },  // V1.04.00
+    { 0x2f69c079f9d53765,   MAAV102 },  // V1.04.01
 };
 
 const ZMap<PackType, decodeFunc> types = {


### PR DESCRIPTION
Decodes the following firmware updaters (FWUpdate.exe):
- Pro M White (.maaV102)
    - V1.06.00
        - https://web.archive.org/web/*/http://update.coolermaster.com/masterkeys-pro-m-white/masterkeys-pro-m-white-v1.06.zip
- Pro L White (.maaV102)
    - V1.08.00
        - https://web.archive.org/web/*/http://update.coolermaster.com/masterkeys-pro-l-white/masterkeys-pro-l-white-v1.08.zip
- Pro S RGB (.maaV101)
    - 1.2.1
        - https://web.archive.org/web/*/http://update.coolermaster.com/masterkeys-pro-s/masterkeys_pro_s_v1.01.zip
        - https://web.archive.org/web/*/http://update.coolermaster.com/masterkeys-pro-s/masterkeys_pro_s_v1.02.zip
    - 1.2.2
        - https://web.archive.org/web/*/http://update.coolermaster.com/masterkeys/masterkeys.zip
- Pro M RGB (.maaV102)
    - V1.04.00
        - https://web.archive.org/web/*/http://update.coolermaster.com/masterkeys-pro-m-rgb/masterkeys_pro_m_v1.03.zip
    - V1.04.01
        - https://web.archive.org/web/*/http://update.coolermaster.com/masterkeys-pro-m-rgb/masterkeys_pro_m_v1.06.zip
- Pro L RGB (.maaV101)
    - 1.2.1
        - https://web.archive.org/web/*/http://update.coolermaster.com/masterkeys-pro-l/masterkeys_pro_l_v1.03.zip
    - 1.2.2
        - https://web.archive.org/web/*/http://update.coolermaster.com/masterkeys-pro-l/masterkeys%20pro%20l%20v1.06.zip
        - https://web.archive.org/web/*/http://update.coolermaster.com/masterkeys-pro-l/masterkeys%20pro%20l%20v1.07.zip