### PR TITLE
[MSYS2/MinGW] Statically link libgcc and libstdc++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,29 +83,7 @@ install(TARGETS pok3rtool DESTINATION bin)
 install(TARGETS pok3rlib DESTINATION lib)
 
 if(MINGW)
-    # Apparently Qt's mingw doesn't come with some static libraries
-    get_filename_component(MINGW_DIR ${CMAKE_CXX_COMPILER} DIRECTORY)
-    set(MINGW_LIBS_DIR "${MINGW_DIR}/../x86_64-w64-mingw32/lib")
-    set(MINGW_LIBGCC "${MINGW_LIBS_DIR}/libgcc_s_seh-1.dll")
-    set(MINGW_LIBSTD "${MINGW_LIBS_DIR}/libstdc++-6.dll")
-    set(MINGW_LIBWPT "${MINGW_LIBS_DIR}/libwinpthread-1.dll")
-
-    add_custom_command(TARGET pok3rtool POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different
-            "${MINGW_LIBGCC}"
-            "$<TARGET_FILE_DIR:pok3rtool>"
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different
-            "${MINGW_LIBSTD}"
-            "$<TARGET_FILE_DIR:pok3rtool>"
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different
-            "${MINGW_LIBWPT}"
-            "$<TARGET_FILE_DIR:pok3rtool>"
-    )
-
-    # intall mingw libraries
-    install(FILES "${MINGW_LIBGCC}" DESTINATION lib)
-    install(FILES "${MINGW_LIBSTD}" DESTINATION lib)
-    install(FILES "${MINGW_LIBWPT}" DESTINATION lib)
+    set(CMAKE_EXE_LINKER_FLAGS "-static-libgcc -static-libstdc++")
 endif()
 
 # Creates C resources file from files in given directory


### PR DESCRIPTION
This commit fixes a build step for MSYS2/QMK_MSYS with MinGW-w64 toolchain by statically linking libgcc and libstdc++ (instead of copying from invalid path).

The previous method of locating libraries in reference to CMAKE_CXX_COMPILER does not work in MSYS2 environments (with `mingw-w64-x86_64-toolchain` toolchain package installed).

Previous method expected to find libraries in:
`/path_with_cxx_compiler/../x86_64-w64-mingw32/lib/`

For reference, required libraries in MSYS2 (MinGW-w64) are located in:
`/mingw64/bin/`

## Install guide for Windows (with this commit):
1. Install MSYS2 from https://www.msys2.org/
2. Launch `MSYS2 MINGW64` console and run the following:
```
pacman -Syu
pacman -S cmake \
        base-devel \
        mingw-w64-x86_64-toolchain \
        mingw-w64-x86_64-cmake \
        git
```
3. Clone repo and build pok3rtool as normal
```
git clone --recursive <pok3rtool_repo>
cd pok3rtool
mkdir build
cd build
cmake ..
# build pok3rtool executable
cmake --build .
# optionally install to C:\Program Files (x86)\Pok3rtool\
cmake --install .
```