### PR TITLE
Add Holtek ISP Protocol

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,8 @@ set(POK3RLIB_SOURCES
     proto_cykb.cpp
     proto_qmk.h
     proto_qmk.cpp
+    proto_holtek.h
+    proto_holtek.cpp
 
     keycodes.h
     keymap.h

--- a/kbproto.h
+++ b/kbproto.h
@@ -11,6 +11,7 @@ using namespace LibChaos;
 enum KBType {
     PROTO_POK3R,    //!< Used in the POK3R and KBP keyboards.
     PROTO_CYKB,     //!< Used in Vortex keyboards marked with CYKB.
+    PROTO_HOLTEK,   //!< Used in Holtek ISP.
 };
 
 enum KBStatus {

--- a/kbscan.cpp
+++ b/kbscan.cpp
@@ -1,6 +1,7 @@
 #include "kbscan.h"
 #include "proto_pok3r.h"
 #include "proto_cykb.h"
+#include "proto_holtek.h"
 
 #include <functional>
 
@@ -13,6 +14,8 @@
 #define INTERFACE_PROTOCOL_NONE 0
 
 #define HOLTEK_VID              0x04d9
+
+#define HOLTEK_ISP_PID          0x8010
 
 #define BOOT_PID                0x1000
 
@@ -34,6 +37,7 @@
 #define MISTEL_MD600_PID        0x0143
 #define MISTEL_MD200_PID        0x0200
 
+#define FW_ADDR_0000            0x0000
 #define FW_ADDR_2C00            0x2c00
 #define FW_ADDR_3200            0x3200
 #define FW_ADDR_3400            0x3400
@@ -59,6 +63,7 @@ static const ZMap<DeviceType, DeviceInfo> known_devices = {
     { DEV_TEX_YODA_II,      { "tex/yoda",           "Tex Yoda II",              HOLTEK_VID, TEX_YODA_II_PID,    BOOT_PID | TEX_YODA_II_PID,     PROTO_CYKB,     FW_ADDR_3400 } },
     { DEV_MISTEL_MD600,     { "mistel/md600",       "Mistel Barocco MD600",     HOLTEK_VID, MISTEL_MD600_PID,   BOOT_PID | MISTEL_MD600_PID,    PROTO_CYKB,     FW_ADDR_3400 } },
     { DEV_MISTEL_MD200,     { "mistel/md200",       "Mistel Freeboard MD200",   HOLTEK_VID, MISTEL_MD200_PID,   BOOT_PID | MISTEL_MD200_PID,    PROTO_CYKB,     FW_ADDR_3400 } },
+    { DEV_HOLTEK_ISP,       { "holtek/isp",         "Holtek ISP USB",           HOLTEK_VID, 0,                  HOLTEK_ISP_PID,                 PROTO_HOLTEK,   FW_ADDR_0000 } },
 };
 
 static ZMap<zu32, DeviceType> known_ids;
@@ -233,6 +238,8 @@ ZList<KBDevice> KBScan::open(){
                 iface = new ProtoPOK3R(ldev.dev.vid, ldev.dev.pid, ldev.dev.boot_pid, ldev.boot, ldev.hid);
             } else if(ldev.dev.type == PROTO_CYKB){
                 iface = new ProtoCYKB(ldev.dev.vid, ldev.dev.pid, ldev.dev.boot_pid, ldev.boot, ldev.hid, ldev.dev.fw_addr);
+            } else if(ldev.dev.type == PROTO_HOLTEK){
+                iface = new ProtoHoltek(ldev.dev.vid, ldev.dev.pid, ldev.dev.boot_pid, ldev.boot, ldev.hid);
             } else {
                 ELOG("Unknown protocol");
                 continue;

--- a/kbscan.h
+++ b/kbscan.h
@@ -27,6 +27,8 @@ enum DeviceType {
     DEV_MISTEL_MD600,   //!< Mistel Barocco MD600
     DEV_MISTEL_MD200,   //!< Mistel Freeboard MD200
 
+    DEV_HOLTEK_ISP,
+
     DEV_QMK_POK3R,
     DEV_QMK_POK3R_RGB,
     DEV_QMK_VORTEX_CORE,

--- a/main.cpp
+++ b/main.cpp
@@ -74,6 +74,8 @@ const ZMap<ZString, DeviceType> devnames = {
 
     { "md200",              DEV_MISTEL_MD200 },
     { "freeboard",          DEV_MISTEL_MD200 },
+
+    { "isp",                DEV_HOLTEK_ISP },
 };
 
 // Functions

--- a/proto_holtek.cpp
+++ b/proto_holtek.cpp
@@ -1,0 +1,381 @@
+#include "proto_holtek.h"
+#include "zlog.h"
+
+#define UPDATE_PKT_LEN          64
+
+#define FW_ADDR                 0x0000
+
+#define HT32F52352_FLASH_LEN    0x20000
+#define HT32F1654_FLASH_LEN     0x10000
+
+#define REBOOT_SLEEP            3
+#define ERASE_SLEEP             5
+
+#define HEX(A) (ZString::ItoS((zu64)(A), 16))
+
+ProtoHoltek::ProtoHoltek(zu16 vid_, zu16 pid_, zu16 boot_pid_) :
+    ProtoQMK(PROTO_HOLTEK, new HIDDevice),
+    builtin(false), debug(false), nop(false),
+    vid(vid_), pid(pid_), boot_pid(boot_pid_)
+{
+
+}
+
+ProtoHoltek::ProtoHoltek(zu16 vid_, zu16 pid_, zu16 boot_pid_, bool builtin_, ZPointer<HIDDevice> dev_) :
+    ProtoQMK(PROTO_HOLTEK, dev_),
+    builtin(builtin_), debug(false), nop(false),
+    vid(vid_), pid(pid_), boot_pid(boot_pid_)
+{
+}
+
+bool ProtoHoltek::open(){
+    if(dev->open(vid, boot_pid, UPDATE_USAGE_PAGE, UPDATE_USAGE)){
+        builtin = true;
+        return true;
+    }
+    return false;
+}
+
+void ProtoHoltek::close(){
+    dev->close();
+}
+
+bool ProtoHoltek::isOpen() const {
+    return dev->isOpen();
+}
+
+bool ProtoHoltek::isBuiltin() {
+    return builtin;
+}
+
+bool ProtoHoltek::rebootFirmware(bool reopen){
+    if(!sendCmd(RESET_CMD, RESET_BOOT_SUBCMD))
+        return false;
+    close();
+
+    if(reopen){
+        ZThread::sleep(REBOOT_SLEEP);
+        if(!open()){
+            ELOG("open error");
+            return false;
+        }
+    }
+    return true;
+}
+
+bool ProtoHoltek::rebootBootloader(bool reopen){
+    if(!sendCmd(RESET_CMD, RESET_BUILTIN_SUBCMD))
+        return false;
+    close();
+
+    if(reopen){
+        ZThread::sleep(REBOOT_SLEEP);
+        if(!open()){
+            ELOG("open error");
+            return false;
+        }
+
+        if(!builtin)
+            return false;
+    }
+    return true;
+}
+
+bool ProtoHoltek::getInfo(){
+    ZBinary data;
+    if(!sendRecvCmd(INFO_CMD, 0, data))
+        return false;
+
+    RLOG(data.dumpBytes(4, 8));
+
+    data.seek(2);
+    zu16 ver = data.readleu16();
+    LOG("ISP version: v" << HEX(ver));
+
+    zu32 model;
+    switch(ver){
+        case 257: // v101
+            data.seek(16);
+            model = data.readleu32();
+            break;
+        case 256: // v100
+            data.rewind();
+            model = (zu32)data.readleu16();
+            break;
+        default: // unknown format
+            model = 0;
+    }
+
+    if(model != 0){
+        LOG("model: HT32F" << HEX(model));
+    } else {
+        LOG("model: unknown");
+    }
+
+    data.seek(6);
+    zu16 page_size = data.readleu16();
+    LOG("page size in bytes: " << page_size);
+
+    data.seek(8);
+    zu32 flash_size = page_size * data.readleu16();
+    LOG("flash size in bytes: " << flash_size);
+
+    // TODO Read Flash Security and Protection
+
+    return true;
+}
+
+ZString ProtoHoltek::getVersion(){
+    DLOG("getVersion");
+
+    ZBinary data;
+    if(!sendRecvCmd(INFO_CMD, 0, data))
+        return false;
+
+    data.seek(2);
+    ZString ver = HEX(data.readleu16());
+    DLOG("version: " << ver);
+
+    return ver;
+}
+
+KBStatus ProtoHoltek::clearVersion(){
+    // Cannot write to bootrom
+    // but report as cleared anyway
+    return SUCCESS;
+}
+
+KBStatus ProtoHoltek::setVersion(ZString version){
+    // Cannot write to bootrom
+    // but report as set anyway
+    return SUCCESS;
+}
+
+ZBinary ProtoHoltek::dumpFlash(){
+    ZBinary dump;
+    zu32 cp = HT32F1654_FLASH_LEN / 10;
+    int perc = 0;
+    RLOG(perc << "%...");
+    for(zu32 addr = 0; addr < HT32F1654_FLASH_LEN; addr += 64){
+        if(!readFlash(addr, dump))
+            break;
+
+        if(addr >= cp){
+            perc += 10;
+            RLOG(perc << "%...");
+            cp += HT32F1654_FLASH_LEN / 10;
+        }
+    }
+    RLOG("100%" << ZLog::NEWLN);
+
+    return dump;
+}
+
+bool ProtoHoltek::writeFirmware(const ZBinary &fwbinin){
+    ZBinary fwbin = fwbinin;
+
+    // TODO check page and flash size with info command
+
+    LOG("Mass Erase...");
+    if(!massEraseFlash()){
+        ELOG("mass erase error");
+        return false;
+    }
+
+    ZThread::sleep(ERASE_SLEEP);
+
+    // reset
+    LOG("Mass erase reset");
+    if(!rebootBootloader(true))
+        return false;
+
+    // clear option bytes
+    if(!eraseFlash(0x1ff00000, 0x1ff00400)){
+        return false;
+    }
+    ZBinary ob(0x400);
+    ob.fill(0xff);
+    for(zu64 o = 0; o < 0x400; o += 52){
+        ZBinary packet;
+        ob.read(packet, 52);
+        if(!writeFlash(0x1ff00000 + o, packet)){
+            return false;
+        }
+    }
+
+    // erase pages
+    if(!eraseFlash(0x0, 0xfbff)){ // HT32F1654
+        ELOG("erase error");
+        return false;
+    }
+
+    ZThread::sleep(ERASE_SLEEP);
+
+    // Write firmware
+    LOG("Write...");
+    for(zu64 o = 0; o < fwbin.size(); o += 52){
+        ZBinary packet;
+        fwbin.read(packet, 52);
+        if(!writeFlash(FW_ADDR + o, packet)){
+            LOG("error writing: 0x" << ZString::ItoS(FW_ADDR + o, 16));
+            return false;
+        }
+    }
+
+    fwbin.rewind();
+
+    LOG("Check...");
+    for(zu64 o = 0; o < fwbin.size(); o += 52){
+        ZBinary packet;
+        fwbin.read(packet, 52);
+        if(!checkFlash(FW_ADDR + o, packet)){
+            LOG("error checking: 0x" << ZString::ItoS(FW_ADDR + o, 16));
+            return false;
+        }
+    }
+    return true;
+}
+
+bool ProtoHoltek::eraseAndCheck(){
+    LOG("Mass Erase...");
+    if(!massEraseFlash()){
+        ELOG("mass erase error");
+        return false;
+    }
+
+    ZThread::sleep(ERASE_SLEEP);
+
+    // reset
+    LOG("Mass erase reset");
+    if(!rebootBootloader(true))
+        return false;
+    return true;
+}
+
+bool ProtoHoltek::readFlash(zu32 addr, ZBinary &bin){
+    DLOG("readFlash " << HEX(addr));
+    // Send command
+    ZBinary data;
+    data.writeleu32(addr);
+    data.writeleu32(addr + 64);
+    if(!sendRecvCmd(FLASH_CMD, FLASH_READ_SUBCMD, data))
+        return false;
+    bin.write(data);
+    return true;
+}
+
+bool ProtoHoltek::writeFlash(zu32 addr, ZBinary bin){
+    DLOG("writeFlash " << HEX(addr) << " " << bin.size());
+    if(!bin.size())
+        return false;
+    // Send command
+    ZBinary arg;
+    arg.writeleu32(addr);
+    arg.writeleu32(addr + bin.size() - 1);
+    arg.write(bin);
+    if(!sendCmd(FLASH_CMD, FLASH_WRITE_SUBCMD, arg))
+        return false;
+    return true;
+}
+
+bool ProtoHoltek::checkFlash(zu32 addr, ZBinary bin){
+    DLOG("checkFlash " << HEX(addr) << " " << bin.size());
+    if(!bin.size())
+        return false;
+    // Send command
+    ZBinary arg;
+    arg.writeleu32(addr);
+    arg.writeleu32(addr + bin.size() - 1);
+    arg.write(bin);
+    if(!sendCmd(FLASH_CMD, FLASH_CHECK_SUBCMD, arg))
+        return false;
+    return true;
+}
+
+bool ProtoHoltek::massEraseFlash(){
+    DLOG("massEraseFlash");
+    // Send command
+    ZBinary arg;
+    arg.writeleu32(0);
+    //arg.writeleu32(0xfbff);
+    arg.writeleu32(0);
+    //if(!sendCmd(ERASE_CMD, ERASE_PAGE_SUBCMD, arg))
+    if(!sendCmd(ERASE_CMD, ERASE_MASS_SUBCMD, arg))
+        return false;
+    return true;
+}
+
+bool ProtoHoltek::eraseFlash(zu32 start, zu32 end){
+    DLOG("eraseFlash " << HEX(start) << " " << end);
+    // Send command
+    ZBinary arg;
+    arg.writeleu32(start);
+    arg.writeleu32(end);
+    if(!sendCmd(ERASE_CMD, ERASE_PAGE_SUBCMD, arg))
+        return false;
+    return true;
+}
+
+zu16 ProtoHoltek::crcFlash(zu32 addr, zu32 len){
+    // Send command
+    ZBinary arg;
+    arg.writeleu32(addr);
+    arg.writeleu32(len);
+    sendCmd(CRC_CMD, 0, arg);
+    return 0;
+}
+
+zu32 ProtoHoltek::baseFirmwareAddr() const {
+    return FW_ADDR;
+}
+
+bool ProtoHoltek::sendCmd(zu8 cmd, zu8 subcmd, ZBinary bin){
+    if(bin.size() > 60){
+        ELOG("bad data size");
+        return false;
+    }
+
+    ZBinary packet(UPDATE_PKT_LEN);
+    packet.fill(0);
+    packet.writeu8(cmd);    // command
+    packet.writeu8(subcmd); // subcommand
+    packet.seek(4);
+    packet.write(bin);      // data
+
+    zu64 se = packet.seek(2);
+    zu16 crc = ZHash<ZBinary, ZHashBase::CRC16>(packet).hash();
+    packet.writeleu16(crc); // CRC
+
+    DLOG("send:");
+    DLOG(ZLog::RAW << packet.dumpBytes(4, 8));
+
+    // Send command (interrupt write)
+    if(!dev->send(packet, (cmd == RESET_CMD ? true : false))){
+        ELOG("send error");
+        return false;
+    }
+    return true;
+}
+
+bool ProtoHoltek::sendRecvCmd(zu8 cmd, zu8 subcmd, ZBinary &data){
+    if(!sendCmd(cmd, subcmd, data))
+        return false;
+
+    // Recv packet
+    data.resize(UPDATE_PKT_LEN);
+    if(!dev->recv(data)){
+        ELOG("recv error");
+        return false;
+    }
+
+    DLOG("recv:");
+    DLOG(ZLog::RAW << data.dumpBytes(4, 8));
+
+    if(data.size() != UPDATE_PKT_LEN){
+        DLOG("bad recv size");
+        return false;
+    }
+
+    data.rewind();
+    return true;
+}

--- a/proto_holtek.h
+++ b/proto_holtek.h
@@ -1,0 +1,103 @@
+#ifndef PROTO_HOLTEK_H
+#define PROTO_HOLTEK_H
+
+#include "kbproto.h"
+#include "proto_qmk.h"
+#include "rawhid/hiddevice.h"
+
+#include "zstring.h"
+#include "zbinary.h"
+using namespace LibChaos;
+
+class ProtoHoltek : public ProtoQMK {
+public:
+    enum pok3r_cmd {
+        ERASE_CMD               = 0,    //! Erase
+        ERASE_PAGE_SUBCMD       = 8,    //! Page erase
+        ERASE_MASS_SUBCMD       = 10,   //! Mass erase
+
+        FLASH_CMD               = 1,    //! Read/write flash
+        FLASH_CHECK_SUBCMD      = 0,    //! Compare bytes in flash with sent bytes
+        FLASH_WRITE_SUBCMD      = 1,    //! Write 52 bytes to flash
+        FLASH_READ_SUBCMD       = 2,    //! Read 64 bytes from flash
+        FLASH_BLANK_SUBCMD      = 3,    //! Blank check bytes in flash
+
+        CRC_CMD                 = 2,    //! CRC part of flash
+
+        INFO_CMD                = 3,    //! Info
+
+        RESET_CMD               = 4,    //! Reset processor
+        RESET_BOOT_SUBCMD       = 0,    //! Reset to opposite firmware (main -> builtin, builtin -> main)
+        RESET_BUILTIN_SUBCMD    = 1,    //! Reset to builtin firmware
+
+        DISCONNECT_CMD          = 5,    //! Only in builtin firmware, disconnect USB and force reset
+    };
+
+public:
+    //! Construct unopened device.
+    ProtoHoltek(zu16 vid, zu16 pid, zu16 boot_pid);
+    //! Construct open device from open HIDDevice.
+    ProtoHoltek(zu16 vid, zu16 pid, zu16 boot_pid, bool builtin, ZPointer<HIDDevice> dev);
+
+    ProtoHoltek(const ProtoHoltek &) = delete;
+    ~ProtoHoltek(){}
+
+    //! Find and open POK3R device.
+    bool open();
+    void close();
+    bool isOpen() const;
+
+    bool isBuiltin();
+
+    //! Reset and re-open device.
+    bool rebootFirmware(bool reopen = true);
+    //! Reset to loader and re-open device.
+    bool rebootBootloader(bool reopen = true);
+
+    bool getInfo();
+
+    //! Read the firmware version from the keyboard.
+    ZString getVersion();
+
+    KBStatus clearVersion();
+    KBStatus setVersion(ZString version);
+
+    //! Dump the contents of flash.
+    ZBinary dumpFlash();
+
+    //! Update the firmware.
+    bool writeFirmware(const ZBinary &fwbin);
+
+    bool eraseAndCheck();
+
+    //! Read 64 bytes at \a addr.
+    bool readFlash(zu32 addr, ZBinary &bin);
+    //! Write 52 bytes at \a addr.
+    bool writeFlash(zu32 addr, ZBinary bin);
+    //! Check 52 bytes at \a addr.
+    bool checkFlash(zu32 addr, ZBinary bin);
+    //! Mass erase flash.
+    bool massEraseFlash();
+    //! Erase flash pages starting at \a start, ending on the page of \a end.
+    bool eraseFlash(zu32 start, zu32 end);
+
+    //! Send CRC command.
+    zu16 crcFlash(zu32 addr, zu32 len);
+
+private:
+    zu32 baseFirmwareAddr() const;
+    //! Send command
+    bool sendCmd(zu8 cmd, zu8 subcmd, ZBinary bin = ZBinary());
+    //! Send command and recv response.
+    bool sendRecvCmd(zu8 cmd, zu8 subcmd, ZBinary &data);
+
+private:
+    bool builtin;
+    bool debug;
+    bool nop;
+    zu16 vid;
+    zu16 pid;
+    zu16 boot_pid;
+};
+
+#endif // PROTO_HOLTEK_H


### PR DESCRIPTION
See #12.

Working commands:
- `info` : prints ISP version, model, page size, flash size
- `wipe` : mass erase device
- `version` : get ISP version
- `reboot` : reboot device

Non-working commands:
- `flash` : certain regions of flash are left unprogrammed (HT32F1654)
- `setversion` : impossible to write to ROM

WIP commands:
- `dump` : dump flash (64 kB always). TODO: get flash size from info.